### PR TITLE
Shift bottom overlays to bottom of screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 yarn-error.log
 package-lock.json
 __snapshots__/
+*.iml

--- a/src/styles/chromecast.scss
+++ b/src/styles/chromecast.scss
@@ -1,5 +1,4 @@
 .chromecast {
-  $bottom: 3.5em;
   $nudge: 5px;
   $middle: 50%;
   $offset-h: -16.5%;
@@ -45,18 +44,18 @@
   }
 
   .chromecast-overlay-bottom-right {
-    bottom: $bottom;
+    bottom: $nudge;
     right: $nudge;
   }
 
   .chromecast-overlay-bottom {
-    bottom: $bottom;
+    bottom: $nudge;
     left: $middle;
     margin-left: $offset-h;
   }
 
   .chromecast-overlay-bottom-left {
-    bottom: $bottom;
+    bottom: $nudge;
     left: $nudge;
   }
 


### PR DESCRIPTION
This PR moves the bottom overlays to the bottom of the screen instead of having them up a little.

This fixes issue #1